### PR TITLE
ci(actions): parametrizing across packages [CNDL-489]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,18 @@
-name: CI
-on:
-  pull_request:
-    branches:
-      - main
+name: Shared CI
 
-defaults:
-  run:
-    working-directory: "packages/npm/send"
+on:
+  workflow_call:
+    inputs:
+      workingDirectory:
+        required: true
+        type: string
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingDirectory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,6 +28,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingDirectory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,6 +43,9 @@ jobs:
 
   build-library:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingDirectory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -50,6 +58,9 @@ jobs:
 
   build-android:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingDirectory }}
     env:
       TURBO_CACHE_DIR: .turbo/android
     steps:
@@ -106,6 +117,9 @@ jobs:
 
   build-ios:
     runs-on: macos-14
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingDirectory }}
     env:
       TURBO_CACHE_DIR: .turbo/ios
     steps:

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -1,0 +1,17 @@
+name: PRs
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  prs:
+    strategy:
+      fail-fast: false
+      matrix:
+        workingDirectory: [ "packages/npm/send" ]
+    uses: ./.github/workflows/ci.yml
+    with:
+      workingDirectory: ${{ matrix.workingDirectory }}
+    secrets: inherit
+    name: ${{ matrix.workingDirectory }}


### PR DESCRIPTION
This PR parametrizes the jobs across services. Unfortunately I can't seem to find a way to share a default across jobs when that default comes from an input, nor can we parametrize all jobs without calling the workflow from another. This solution seems not so bad, just means the default has to be included in every job once. 

Additionally the name of the status checks becomes more verbose, which I can't seem to resolve. Obviously we want the name to include the file path, I just can't get rid of the `PRs / ` prefix. 

The PR is ready for review/merge, just note when we're ready to do so we'll need to update the repo's required status checks list. 