### PR TITLE
ci(release): fixing release script automation [CNDL-488]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup
         uses: ./.github/actions/setup
+
+      - name: Initialize the Npm Config
+        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build package
         run: yarn prepare

--- a/packages/npm/send/package.json
+++ b/packages/npm/send/package.json
@@ -98,6 +98,7 @@
   },
   "release-it": {
     "git": {
+      "requiredBranch": "main",
       "commitMessage": "chore: release ${version}",
       "tagName": "v${version}",
       "push": true
@@ -113,6 +114,9 @@
         "preset": "angular",
         "infile": "CHANGELOG.md"
       }
+    },
+    "publishConfig": {
+      "registry": "https://registry.npmjs.org/"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
This should make the release job work. I tested it on a non-main branch and it seems to have worked - I can't confirm whether a package was published to the npm repo without login creds but it says it passed and it pushed a release to GitHub. I deleted that release and tag to clean up. Once this PR is merged we should confirm all works as expected before considering this work done