### PR TITLE
ci(github-packages): adding publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,36 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Re-configure publishing for npmjs
+        run: |
+          sed -i 's#    "registry": "https://npm.pkg.github.com/"#    "registry": "https://registry.npmjs.org/"#' package.json
+          sed -i 's#      "push": true#      "push": false#' package.json
+          sed -i 's#      "release": true#      "release": false#' package.json
+          git update-index --assume-unchanged package.json
+          git update-index --assume-unchanged CHANGELOG.md
+
       - name: Build package
         run: yarn prepare
 
-      - name: Publish package
+      - name: Publish package to npmjs
+        run: yarn release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Initialize the git registry Config
+        run: npm config set //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-configure publishing for GitHub Packages
+        run: |
+          git update-index --no-assume-unchanged package.json
+          git update-index --no-assume-unchanged CHANGELOG.md
+          git checkout package.json
+          git checkout CHANGELOG.md
+          git tag -d $(git tag -l)
+
+      - name: Publish package to GitHub
         run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/npm/send/package.json
+++ b/packages/npm/send/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/candlefinance/oss#readme",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com/"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",
@@ -114,9 +114,6 @@
         "preset": "angular",
         "infile": "CHANGELOG.md"
       }
-    },
-    "publishConfig": {
-      "registry": "https://registry.npmjs.org/"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
Releasing to two places gets a little complicated given that release-it requires that `git status` return clean in order to run. We can hide changes from git, but hiding changes to `package.json` means the version bump won't push. 

To work around these, the solution I'm using is to:
1. Commit in the config of publishing to GitHub,
2. In CICD set it to npmjs and ignore changes to package.json without the intent to commit that change
3. Publish just the package to npmjs
4. Revert the changes made above and by release-it (the version bump and changelog)
5. Publish again, this time to GitHub packages, github releases/tags, and commit/push the changelog and version bump